### PR TITLE
ENH: stop instead of message for non-factor 0/1 outcome

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -44,7 +44,7 @@ check_tmt <- function(tmt) {
 check_y <- function(y) {
   if (is.numeric(y)) {
     if (setequal(y, c(0, 1))) {
-      message("y only has 1/0 to model a binary outcome, y must be a factor")
+      stop("y only has 1/0, to model a binary outcome, y must be a factor")
     }
 
     # don't need to do anything in this case

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1,0 +1,7 @@
+context("util")
+
+test_that("error on non-factor 0/1 outcome", {
+  y <- c(0, 1, 1, 0, 1, 1)
+
+  expect_error(check_y(y), "y only has 1/0, to model a binary outcome, y must be a factor")
+})


### PR DESCRIPTION
This causes problems for any models which use the type of the outcome variable to decide between regression and classification. 